### PR TITLE
fix: resolve input issues and cursor reset in EditableDiv for Firefox

### DIFF
--- a/src/pages/machine/TuringEdge.tsx
+++ b/src/pages/machine/TuringEdge.tsx
@@ -17,24 +17,29 @@ const EditableDiv = ({
   const contentEditableRef = useRef(null);
 
   useEffect(() => {
-    // Set the content of the div when edgeValue changes
     if (contentEditableRef.current) {
       // @ts-ignore
-      contentEditableRef.current.textContent = edgeValue;
+      const currentText = contentEditableRef.current.textContent;
+      if (currentText !== edgeValue) {
+        // @ts-ignore
+        contentEditableRef.current.textContent = edgeValue;
+      }
     }
   }, [edgeValue]);
 
   const handleInput = () => {
     if (contentEditableRef.current) {
-      // Update value in parent component when content changes
-      // @ts-ignore
-      onChangeHandler(contentEditableRef.current.textContent);
+      if (contentEditableRef.current) {
+        // @ts-ignore
+        const text = contentEditableRef.current.textContent || '';
+        onChangeHandler(text);
+      }
     }
   };
 
   return (
     <div
-      contentEditable="plaintext-only"
+      contentEditable="true"
       ref={contentEditableRef}
       className="min-w-14 px-2 bg-white border rounded-sm text-center text-lg overflow-auto cursor-text"
       onInput={handleInput}


### PR DESCRIPTION
- Change contentEditable attribute to "true" for compatibility with Firefox, enabling input functionality (working both in Firefox and Chrome). ^ This gave an another issue, which was fixed below

- Modify the EditableDiv component to update textContent only when the edgeValue prop changes externally, preventing unnecessary re-renders and cursor resets.

- Ensure consistent behavior across browsers and maintain the cursor position during user input.